### PR TITLE
test: Add Spark component to Whisk CRD schema

### DIFF
--- a/stress-test/olaris-stress/setup/kubernetes/crds/whisk-crd.yaml
+++ b/stress-test/olaris-stress/setup/kubernetes/crds/whisk-crd.yaml
@@ -120,6 +120,9 @@ spec:
                     postgres:
                       description: deploys postgress if supported by the operator
                       type: boolean                      
+                    spark:
+                      description: deploys Apache Spark if supported by the operator
+                      type: boolean
                   required:
                     - openwhisk
                     - couchdb


### PR DESCRIPTION
## Summary

Add Spark component support to the Whisk CRD schema for testing.

## Changes

- Add `spark` boolean field to components schema in `whisk-crd.yaml`
- Enables Spark testing configuration in stress tests

## Related PRs

- apache/openserverless-operator#77 (Spark implementation)
- apache/openserverless#188 (Main integration PR)

Part of the Apache Spark integration for OpenServerless.