### PR TITLE
Add operator PR testing workflow

### DIFF
--- a/.github/workflows/operator-pr-test.yaml
+++ b/.github/workflows/operator-pr-test.yaml
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: Operator PR Test
+run-name: "Operator PR #${{ github.event.client_payload.pr_number }} on ${{ github.event.client_payload.platform }}"
+
+on:
+  repository_dispatch:
+    types: [operator-pr-test]
+
+env:
+  PR_NUMBER: ${{ github.event.client_payload.pr_number }}
+  PR_REF: ${{ github.event.client_payload.pr_ref }}
+  PR_SHA: ${{ github.event.client_payload.pr_sha }}
+  OPERATOR_REPO: ${{ github.event.client_payload.operator_repo }}
+  PLATFORM: ${{ github.event.client_payload.platform }}
+  OPERATOR_IMAGE: ghcr.io/${{ github.repository_owner }}/openserverless-testing
+
+  # --- k3s single-VM platforms ---
+  K3S_AMD_IP: ${{ secrets.K3S_AMD_IP }}
+  K3S_ARM_IP: ${{ secrets.K3S_ARM_IP }}
+  ID_RSA_B64: ${{ secrets.ID_RSA_B64 }}
+  SSH_USER: ${{ secrets.SSH_USER || 'root' }}
+
+  # --- Generic K8s cluster (kubeconfig-based) ---
+  K8S_KUBECONFIG_B64: ${{ secrets.K8S_KUBECONFIG_B64 }}
+
+  # --- Per-platform DNS FQDN ---
+  K3S_AMD_APIHOST: ${{ secrets.K3S_AMD_APIHOST }}
+  K3S_ARM_APIHOST: ${{ secrets.K3S_ARM_APIHOST }}
+  K8S_APIHOST: ${{ secrets.K8S_APIHOST }}
+  APIHOST: ${{ secrets.APIHOST }}
+
+  # --- Debug ---
+  NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
+  NGROK_PASSWORD: ${{ secrets.NGROK_PASSWORD }}
+
+jobs:
+  operator-pr-test:
+    name: "Test operator PR #${{ github.event.client_payload.pr_number }}"
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout testing repo
+        uses: actions/checkout@v4
+
+      - name: Clone operator PR branch with submodules
+        run: |
+          git clone --recurse-submodules --branch "$PR_REF" \
+            "https://github.com/$OPERATOR_REPO.git" _operator
+
+      - name: Verify submodule
+        run: |
+          echo "Checking olaris/ submodule content..."
+          ls _operator/olaris/opsfile.yml _operator/olaris/opsroot.json
+          echo "Submodule OK"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push operator image
+        id: build
+        run: |
+          SHORT_SHA="${PR_SHA:0:7}"
+          IMAGE_TAG="pr-${PR_NUMBER}-${SHORT_SHA}"
+          FULL_IMAGE="${OPERATOR_IMAGE}:${IMAGE_TAG}"
+          echo "Building ${FULL_IMAGE} from _operator/"
+          docker build -t "${FULL_IMAGE}" _operator/
+          docker push "${FULL_IMAGE}"
+          echo "image_ref=${FULL_IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Patch opsroot.json with PR image
+        run: |
+          jq --arg img "${{ steps.build.outputs.image_ref }}" \
+            '.config.images.operator = $img' \
+            _operator/olaris/opsroot.json > _operator/olaris/opsroot.json.tmp
+          mv _operator/olaris/opsroot.json.tmp _operator/olaris/opsroot.json
+          echo "Patched opsroot.json:"
+          cat _operator/olaris/opsroot.json
+
+      - name: Set OPS_ROOT
+        run: echo "OPS_ROOT=$(pwd)/_operator/olaris" >> "$GITHUB_ENV"
+
+      - name: Install ops
+        run: |
+          curl -sL bit.ly/get-ops | bash
+          ops -info
+          ops -t > /dev/null
+
+      - name: 1 Deploy
+        run: |
+          touch .secrets
+          tests/1-deploy.sh $PLATFORM
+      - name: 3 SysRedis
+        run: tests/3-sys-redis.sh $PLATFORM
+      - name: 4 SysMongo
+        run: tests/4a-sys-ferretdb.sh $PLATFORM
+      - name: 4b SysPostgres
+        run: tests/4b-sys-postgres.sh $PLATFORM
+      - name: 5 SysMinio
+        run: tests/5-sys-minio.sh $PLATFORM
+      - name: 6 Login
+        run: tests/6-login.sh $PLATFORM
+      - name: 7 Static
+        run: tests/7-static.sh $PLATFORM
+      - name: 8 UserRedis
+        run: tests/8-user-redis.sh $PLATFORM
+      - name: 9a UserFerretDB
+        run: tests/9a-user-ferretdb.sh $PLATFORM
+      - name: 9b UserPostgres
+        run: tests/9b-user-postgres.sh $PLATFORM
+      - name: 10 UserMinio
+        run: tests/10-user-minio.sh $PLATFORM
+      - name: 14 RuntimeTesting
+        run: tests/14-runtime-testing.sh $PLATFORM

--- a/.github/workflows/operator-pr-test.yaml
+++ b/.github/workflows/operator-pr-test.yaml
@@ -30,24 +30,7 @@ env:
   PLATFORM: ${{ github.event.client_payload.platform }}
   OPERATOR_IMAGE: ghcr.io/${{ github.repository_owner }}/openserverless-testing
 
-  # --- k3s single-VM platforms ---
-  K3S_AMD_IP: ${{ secrets.K3S_AMD_IP }}
-  K3S_ARM_IP: ${{ secrets.K3S_ARM_IP }}
-  ID_RSA_B64: ${{ secrets.ID_RSA_B64 }}
-  SSH_USER: ${{ secrets.SSH_USER || 'root' }}
-
-  # --- Generic K8s cluster (kubeconfig-based) ---
-  K8S_KUBECONFIG_B64: ${{ secrets.K8S_KUBECONFIG_B64 }}
-
-  # --- Per-platform DNS FQDN ---
-  K3S_AMD_APIHOST: ${{ secrets.K3S_AMD_APIHOST }}
-  K3S_ARM_APIHOST: ${{ secrets.K3S_ARM_APIHOST }}
-  K8S_APIHOST: ${{ secrets.K8S_APIHOST }}
-  APIHOST: ${{ secrets.APIHOST }}
-
-  # --- Debug ---
   NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
-  NGROK_PASSWORD: ${{ secrets.NGROK_PASSWORD }}
 
 jobs:
   operator-pr-test:
@@ -108,6 +91,23 @@ jobs:
           curl -sL bit.ly/get-ops | bash
           ops -info
           ops -t > /dev/null
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SSH_KEY: op://OpenServerless/ops_testing_ssh/public key
+          NGROK_PASSWORD: op://OpenServerless/TESTING/NGROK_PASSWORD
+          K3S_AMD_IP: op://OpenServerless/TESTING/K3S_AMD_IP
+          K3S_ARM_IP: op://OpenServerless/TESTING/K3S_ARM_IP
+          ID_RSA_B64: op://OpenServerless/TESTING/ID_RSA_B64
+          K8S_KUBECONFIG_B64: op://OpenServerless/TESTING/K8S_KUBECONFIG_B64
+          K3S_AMD_APIHOST: op://OpenServerless/TESTING/K3S_AMD_APIHOST
+          K3S_ARM_APIHOST: op://OpenServerless/TESTING/K3S_ARM_APIHOST
+          K8S_APIHOST: op://OpenServerless/TESTING/K8S_APIHOST
+          APIHOST: op://OpenServerless/TESTING/APIHOST
 
       - name: 1 Deploy
         run: |

--- a/.github/workflows/operator-pr-test.yaml
+++ b/.github/workflows/operator-pr-test.yaml
@@ -100,8 +100,6 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SSH_KEY: op://OpenServerless/ops_testing_ssh/public key
           NGROK_PASSWORD: op://OpenServerless/TESTING/NGROK_PASSWORD
-          K3S_AMD_IP: op://OpenServerless/TESTING/K3S_AMD_IP
-          K3S_ARM_IP: op://OpenServerless/TESTING/K3S_ARM_IP
           ID_RSA_B64: op://OpenServerless/TESTING/ID_RSA_B64
           K8S_KUBECONFIG_B64: op://OpenServerless/TESTING/K8S_KUBECONFIG_B64
           K3S_AMD_APIHOST: op://OpenServerless/TESTING/K3S_AMD_APIHOST

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,6 @@ on:
   push:
     tags:
     - '*-*'
-    branches-ignore: '*'
 
 env:
   PLATFORM: ${{ github.ref_name }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,43 +25,9 @@ on:
 
 env:
   PLATFORM: ${{ github.ref_name }}
-
-  # --- Task definitions ---
   OPS_REPO: ${{ vars.OPS_REPO || 'https://github.com/apache/openserverless-task' }}
   OPS_BRANCH: ${{ vars.OPS_BRANCH || 'main' }}
-
-  # --- k3s single-VM platforms ---
-  K3S_AMD_IP: ${{ secrets.K3S_AMD_IP }}
-  K3S_ARM_IP: ${{ secrets.K3S_ARM_IP }}
-  ID_RSA_B64: ${{ secrets.ID_RSA_B64 }}
-  SSH_USER: ${{ secrets.SSH_USER || 'root' }}
-
-  # --- Generic K8s cluster (kubeconfig-based) ---
-  K8S_KUBECONFIG_B64: ${{ secrets.K8S_KUBECONFIG_B64 }}
-
-  # --- Per-platform DNS FQDN (hierarchy: <PLATFORM>_APIHOST -> APIHOST -> hardcoded default) ---
-  #TODO: Check if the hardcoded `api.k3s.opstest.top` is still valid  
-  K3S_AMD_APIHOST: ${{ secrets.K3S_AMD_APIHOST }}
-  K3S_ARM_APIHOST: ${{ secrets.K3S_ARM_APIHOST }}
-  K8S_APIHOST: ${{ secrets.K8S_APIHOST }}
-  APIHOST: ${{ secrets.APIHOST }}
-
-  # --- Debug: ngrok SSH tunnel for interactive debugging ---
   NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
-  NGROK_PASSWORD: ${{ secrets.NGROK_PASSWORD }}
-
-  # --- Commented out: cloud providers not currently in use ---
-  # USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
-  # MK8S_IP: ${{ secrets.MK8S_IP }}
-  # AKS_KUBECONFIG_B64: ${{ secrets.AKS_KUBECONFIG_B64 }}
-  # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  # AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-  # AWS_SSHKEY: ${{ secrets.AWS_SSHKEY }}
-  # EKS_KUBECONFIG_B64: ${{ secrets.EKS_KUBECONFIG_B64 }}
-  # GKE_KUBECONFIG_B64: ${{ secrets.GKE_KUBECONFIG_B64 }}
-  # OPENSHIFT_KUBECONFIG_B64: ${{ secrets.OPENSHIFT_KUBECONFIG_B64 }}
-  # GCLOUD_SERVICE_ACCOUNT_B64: ${{ secrets.GCLOUD_SERVICE_ACCOUNT_B64 }}
 
 jobs:
   test-linux:
@@ -85,6 +51,32 @@ jobs:
           curl -sL bit.ly/get-ops | bash
           ops -info
           ops -t > /dev/null
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SSH_KEY: op://OpenServerless/ops_testing_ssh/public key
+          NGROK_PASSWORD: op://OpenServerless/TESTING/NGROK_PASSWORD
+          K3S_AMD_IP: op://OpenServerless/TESTING/K3S_AMD_IP
+          K3S_ARM_IP: op://OpenServerless/TESTING/K3S_ARM_IP
+          ID_RSA_B64: op://OpenServerless/TESTING/ID_RSA_B64
+          K8S_KUBECONFIG_B64: op://OpenServerless/TESTING/K8S_KUBECONFIG_B64
+          K3S_AMD_APIHOST: op://OpenServerless/TESTING/K3S_AMD_APIHOST
+          K3S_ARM_APIHOST: op://OpenServerless/TESTING/K3S_ARM_APIHOST
+          K8S_APIHOST: op://OpenServerless/TESTING/K8S_APIHOST
+          APIHOST: op://OpenServerless/TESTING/APIHOST
+          # Uncomment when cloud providers are re-enabled:
+          # AKS_KUBECONFIG_B64: op://OpenServerless/TESTING/AKS_KUBECONFIG_B64
+          # AWS_ACCESS_KEY_ID: op://OpenServerless/TESTING/AWS_ACCESS_KEY_ID
+          # AWS_SECRET_ACCESS_KEY: op://OpenServerless/TESTING/AWS_SECRET_ACCESS_KEY
+          # AWS_DEFAULT_REGION: op://OpenServerless/TESTING/AWS_DEFAULT_REGION
+          # AWS_SSHKEY: op://OpenServerless/TESTING/AWS_SSHKEY
+          # EKS_KUBECONFIG_B64: op://OpenServerless/TESTING/EKS_KUBECONFIG_B64
+          # GKE_KUBECONFIG_B64: op://OpenServerless/TESTING/GKE_KUBECONFIG_B64
+          # OPENSHIFT_KUBECONFIG_B64: op://OpenServerless/TESTING/OPENSHIFT_KUBECONFIG_B64
+          # GCLOUD_SERVICE_ACCOUNT_B64: op://OpenServerless/TESTING/GCLOUD_SERVICE_ACCOUNT_B64
       - name: Debug Action (if requested)
         run:  .github/debugAction.sh
       - name: Wait for Debug (if requested)
@@ -155,6 +147,23 @@ jobs:
         run: |
           ops -update
           ops -info
+      - name: Load secrets from 1Password
+        uses: shyim/1password-load-secrets-action@v1
+        with:
+          export: true
+          mask-secrets: true
+          secrets: |
+            op://OpenServerless/TESTING/NGROK_PASSWORD
+            op://OpenServerless/TESTING/K3S_AMD_IP
+            op://OpenServerless/TESTING/K3S_ARM_IP
+            op://OpenServerless/TESTING/ID_RSA_B64
+            op://OpenServerless/TESTING/K8S_KUBECONFIG_B64
+            op://OpenServerless/TESTING/K3S_AMD_APIHOST
+            op://OpenServerless/TESTING/K3S_ARM_APIHOST
+            op://OpenServerless/TESTING/K8S_APIHOST
+            op://OpenServerless/TESTING/APIHOST
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: 1 Deploy
         shell: bash
@@ -228,6 +237,32 @@ jobs:
           ops -t > /dev/null
           OPS_BIN_PATH=$(ops -i | grep "OPS_HOME" | awk -v FS=: '{print $2}' | tr -d " ")/bin
           echo "PATH=$OPS_BIN_PATH:$PATH" >> $GITHUB_ENV
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SSH_KEY: op://OpenServerless/ops_testing_ssh/public key
+          NGROK_PASSWORD: op://OpenServerless/TESTING/NGROK_PASSWORD
+          K3S_AMD_IP: op://OpenServerless/TESTING/K3S_AMD_IP
+          K3S_ARM_IP: op://OpenServerless/TESTING/K3S_ARM_IP
+          ID_RSA_B64: op://OpenServerless/TESTING/ID_RSA_B64
+          K8S_KUBECONFIG_B64: op://OpenServerless/TESTING/K8S_KUBECONFIG_B64
+          K3S_AMD_APIHOST: op://OpenServerless/TESTING/K3S_AMD_APIHOST
+          K3S_ARM_APIHOST: op://OpenServerless/TESTING/K3S_ARM_APIHOST
+          K8S_APIHOST: op://OpenServerless/TESTING/K8S_APIHOST
+          APIHOST: op://OpenServerless/TESTING/APIHOST
+          # Uncomment when cloud providers are re-enabled:
+          # AKS_KUBECONFIG_B64: op://OpenServerless/TESTING/AKS_KUBECONFIG_B64
+          # AWS_ACCESS_KEY_ID: op://OpenServerless/TESTING/AWS_ACCESS_KEY_ID
+          # AWS_SECRET_ACCESS_KEY: op://OpenServerless/TESTING/AWS_SECRET_ACCESS_KEY
+          # AWS_DEFAULT_REGION: op://OpenServerless/TESTING/AWS_DEFAULT_REGION
+          # AWS_SSHKEY: op://OpenServerless/TESTING/AWS_SSHKEY
+          # EKS_KUBECONFIG_B64: op://OpenServerless/TESTING/EKS_KUBECONFIG_B64
+          # GKE_KUBECONFIG_B64: op://OpenServerless/TESTING/GKE_KUBECONFIG_B64
+          # OPENSHIFT_KUBECONFIG_B64: op://OpenServerless/TESTING/OPENSHIFT_KUBECONFIG_B64
+          # GCLOUD_SERVICE_ACCOUNT_B64: op://OpenServerless/TESTING/GCLOUD_SERVICE_ACCOUNT_B64
       - name: Debug Action (if requested)
         run: .github/debugAction.sh
       - name: Wait for Debug (if requested)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,24 +59,12 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SSH_KEY: op://OpenServerless/ops_testing_ssh/public key
           NGROK_PASSWORD: op://OpenServerless/TESTING/NGROK_PASSWORD
-          K3S_AMD_IP: op://OpenServerless/TESTING/K3S_AMD_IP
-          K3S_ARM_IP: op://OpenServerless/TESTING/K3S_ARM_IP
           ID_RSA_B64: op://OpenServerless/TESTING/ID_RSA_B64
           K8S_KUBECONFIG_B64: op://OpenServerless/TESTING/K8S_KUBECONFIG_B64
           K3S_AMD_APIHOST: op://OpenServerless/TESTING/K3S_AMD_APIHOST
           K3S_ARM_APIHOST: op://OpenServerless/TESTING/K3S_ARM_APIHOST
           K8S_APIHOST: op://OpenServerless/TESTING/K8S_APIHOST
           APIHOST: op://OpenServerless/TESTING/APIHOST
-          # Uncomment when cloud providers are re-enabled:
-          # AKS_KUBECONFIG_B64: op://OpenServerless/TESTING/AKS_KUBECONFIG_B64
-          # AWS_ACCESS_KEY_ID: op://OpenServerless/TESTING/AWS_ACCESS_KEY_ID
-          # AWS_SECRET_ACCESS_KEY: op://OpenServerless/TESTING/AWS_SECRET_ACCESS_KEY
-          # AWS_DEFAULT_REGION: op://OpenServerless/TESTING/AWS_DEFAULT_REGION
-          # AWS_SSHKEY: op://OpenServerless/TESTING/AWS_SSHKEY
-          # EKS_KUBECONFIG_B64: op://OpenServerless/TESTING/EKS_KUBECONFIG_B64
-          # GKE_KUBECONFIG_B64: op://OpenServerless/TESTING/GKE_KUBECONFIG_B64
-          # OPENSHIFT_KUBECONFIG_B64: op://OpenServerless/TESTING/OPENSHIFT_KUBECONFIG_B64
-          # GCLOUD_SERVICE_ACCOUNT_B64: op://OpenServerless/TESTING/GCLOUD_SERVICE_ACCOUNT_B64
       - name: Debug Action (if requested)
         run:  .github/debugAction.sh
       - name: Wait for Debug (if requested)
@@ -154,8 +142,6 @@ jobs:
           mask-secrets: true
           secrets: |
             op://OpenServerless/TESTING/NGROK_PASSWORD
-            op://OpenServerless/TESTING/K3S_AMD_IP
-            op://OpenServerless/TESTING/K3S_ARM_IP
             op://OpenServerless/TESTING/ID_RSA_B64
             op://OpenServerless/TESTING/K8S_KUBECONFIG_B64
             op://OpenServerless/TESTING/K3S_AMD_APIHOST
@@ -245,24 +231,12 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SSH_KEY: op://OpenServerless/ops_testing_ssh/public key
           NGROK_PASSWORD: op://OpenServerless/TESTING/NGROK_PASSWORD
-          K3S_AMD_IP: op://OpenServerless/TESTING/K3S_AMD_IP
-          K3S_ARM_IP: op://OpenServerless/TESTING/K3S_ARM_IP
           ID_RSA_B64: op://OpenServerless/TESTING/ID_RSA_B64
           K8S_KUBECONFIG_B64: op://OpenServerless/TESTING/K8S_KUBECONFIG_B64
           K3S_AMD_APIHOST: op://OpenServerless/TESTING/K3S_AMD_APIHOST
           K3S_ARM_APIHOST: op://OpenServerless/TESTING/K3S_ARM_APIHOST
           K8S_APIHOST: op://OpenServerless/TESTING/K8S_APIHOST
           APIHOST: op://OpenServerless/TESTING/APIHOST
-          # Uncomment when cloud providers are re-enabled:
-          # AKS_KUBECONFIG_B64: op://OpenServerless/TESTING/AKS_KUBECONFIG_B64
-          # AWS_ACCESS_KEY_ID: op://OpenServerless/TESTING/AWS_ACCESS_KEY_ID
-          # AWS_SECRET_ACCESS_KEY: op://OpenServerless/TESTING/AWS_SECRET_ACCESS_KEY
-          # AWS_DEFAULT_REGION: op://OpenServerless/TESTING/AWS_DEFAULT_REGION
-          # AWS_SSHKEY: op://OpenServerless/TESTING/AWS_SSHKEY
-          # EKS_KUBECONFIG_B64: op://OpenServerless/TESTING/EKS_KUBECONFIG_B64
-          # GKE_KUBECONFIG_B64: op://OpenServerless/TESTING/GKE_KUBECONFIG_B64
-          # OPENSHIFT_KUBECONFIG_B64: op://OpenServerless/TESTING/OPENSHIFT_KUBECONFIG_B64
-          # GCLOUD_SERVICE_ACCOUNT_B64: op://OpenServerless/TESTING/GCLOUD_SERVICE_ACCOUNT_B64
       - name: Debug Action (if requested)
         run: .github/debugAction.sh
       - name: Wait for Debug (if requested)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,11 +26,42 @@ on:
 
 env:
   PLATFORM: ${{ github.ref_name }}
-  USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
-  OPS_REPO: https://github.com/apache/openserverless-task
-  OPS_BRANCH: main
+
+  # --- Task definitions ---
+  OPS_REPO: ${{ vars.OPS_REPO || 'https://github.com/apache/openserverless-task' }}
+  OPS_BRANCH: ${{ vars.OPS_BRANCH || 'main' }}
+
+  # --- k3s single-VM platforms ---
+  K3S_AMD_IP: ${{ secrets.K3S_AMD_IP }}
+  K3S_ARM_IP: ${{ secrets.K3S_ARM_IP }}
+  ID_RSA_B64: ${{ secrets.ID_RSA_B64 }}
+
+  # --- Generic K8s cluster (kubeconfig-based) ---
+  K8S_KUBECONFIG_B64: ${{ secrets.K8S_KUBECONFIG_B64 }}
+
+  # --- Per-platform DNS FQDN (hierarchy: <PLATFORM>_APIHOST -> APIHOST -> hardcoded default) ---
+  #TODO: Check if the hardcoded `api.k3s.opstest.top` is still valid  
+  K3S_AMD_APIHOST: ${{ secrets.K3S_AMD_APIHOST }}
+  K3S_ARM_APIHOST: ${{ secrets.K3S_ARM_APIHOST }}
+  K8S_APIHOST: ${{ secrets.K8S_APIHOST }}
+  APIHOST: ${{ secrets.APIHOST }}
+
+  # --- Debug: ngrok SSH tunnel for interactive debugging ---
   NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
-  #NGROK_PASSWORD: ${{ secrets.NGROK_PASSWORD }}
+  NGROK_PASSWORD: ${{ secrets.NGROK_PASSWORD }}
+
+  # --- Commented out: cloud providers not currently in use ---
+  # USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
+  # MK8S_IP: ${{ secrets.MK8S_IP }}
+  # AKS_KUBECONFIG_B64: ${{ secrets.AKS_KUBECONFIG_B64 }}
+  # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  # AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+  # AWS_SSHKEY: ${{ secrets.AWS_SSHKEY }}
+  # EKS_KUBECONFIG_B64: ${{ secrets.EKS_KUBECONFIG_B64 }}
+  # GKE_KUBECONFIG_B64: ${{ secrets.GKE_KUBECONFIG_B64 }}
+  # OPENSHIFT_KUBECONFIG_B64: ${{ secrets.OPENSHIFT_KUBECONFIG_B64 }}
+  # GCLOUD_SERVICE_ACCOUNT_B64: ${{ secrets.GCLOUD_SERVICE_ACCOUNT_B64 }}
 
 jobs:
   test-linux:
@@ -40,43 +71,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Add Missing plugin
-        run: |
-          # fix for missing auth-plugin
-          echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-          sudo apt update
-          sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin kubectl  
-        if: ${{ startsWith(github.ref_name, 'gke') }}
+      # Commented out -- GKE plugin not needed without GCP environment:
+      # - name: Add Missing plugin
+      #   run: |
+      #     # fix for missing auth-plugin
+      #     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+      #     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+      #     sudo apt update
+      #     sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin kubectl
+      #   if: ${{ startsWith(github.ref_name, 'gke') }}
       - name: Install ops
         run: |
-          curl -sL bit.ly/get-ops | bash          
+          curl -sL bit.ly/get-ops | bash
           ops -info
           ops -t > /dev/null
-      - name: Load secret
-        uses: 1password/load-secrets-action@v2
-        with:
-          # Export loaded secrets as environment variables
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          SSH_KEY: op://OpenServerless/ops_testing_ssh/public key
-          NGROK_PASSWORD: op://OpenServerless/TESTING/NGROK_PASSWORD
-          K3S_IP: op://OpenServerless/TESTING/K3S_IP
-          MK8S_IP: op://OpenServerless/TESTING/MK8S_IP
-          ID_RSA_B64: op://OpenServerless/TESTING/ID_RSA_B64
-          AKS_KUBECONFIG_B64: op://OpenServerless/TESTING/AKS_KUBECONFIG_B64
-          AWS_ACCESS_KEY_ID: op://OpenServerless/TESTING/AWS_ACCESS_KEY_ID
-          AWS_SECRET_ACCESS_KEY: op://OpenServerless/TESTING/AWS_SECRET_ACCESS_KEY
-          AWS_DEFAULT_REGION: op://OpenServerless/TESTING/AWS_DEFAULT_REGION
-          AWS_SSHKEY: op://OpenServerless/TESTING/AWS_SSHKEY
-          EKS_KUBECONFIG_B64: op://OpenServerless/TESTING/EKS_KUBECONFIG_B64
-          #GKE_KUBECONFIG_B64: op://OpenServerless/TESTING/GKE_KUBECONFIG_B64
-          #OPENSHIFT_KUBECONFIG_B64: op://OpenServerless/TESTING/OPENSHIFT_KUBECONFIG_B64
-          #AWS_ACCESS_KEY_ID: op://OpenServerless/TESTING/AWS_ACCESS_KEY_ID
-          #AWS_SECRET_ACCESS_KEY: op://OpenServerless/TESTING/AWS_SECRET_ACCESS_KEY
-          #GCLOUD_SERVICE_ACCOUNT_B64: op://OpenServerless/TESTING/GCLOUD_SERVICE_ACCOUNT_B64
-
       - name: Debug Action (if requested)
         run:  .github/debugAction.sh
       - name: Wait for Debug (if requested)
@@ -121,38 +129,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         # Install Git (which includes Git Bash)
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-        if: ${{ startsWith(github.ref_name, 'gke') }}
-      - name: 'Update plugin'
-        if: ${{ startsWith(github.ref_name, 'gke') }}
-        run: gcloud components install gke-gcloud-auth-plugin
-      - name: Load secrets
-        uses: shyim/1password-load-secrets-action@v1
-        with:
-          # export also as environment variable
-          export: true
-          # mask the secrets in the logs
-          mask-secrets: true
-          # secret mapping
-          secrets: |
-            op://OpenServerless/TESTING/NGROK_PASSWORD
-            op://OpenServerless/TESTING/K3S_IP
-            op://OpenServerless/TESTING/MK8S_IP
-            op://OpenServerless/TESTING/ID_RSA_B64
-            op://OpenServerless/TESTING/AKS_KUBECONFIG_B64
-            op://OpenServerless/TESTING/AWS_ACCESS_KEY_ID
-            op://OpenServerless/TESTING/AWS_SECRET_ACCESS_KEY
-            op://OpenServerless/TESTING/AWS_DEFAULT_REGION
-            op://OpenServerless/TESTING/AWS_SSHKEY
-            op://OpenServerless/TESTING/EKS_KUBECONFIG_B64
-          #GKE_KUBECONFIG_B64: op://OpenServerless/TESTING/GKE_KUBECONFIG_B64
-          #OPENSHIFT_KUBECONFIG_B64: op://OpenServerless/TESTING/OPENSHIFT_KUBECONFIG_B64
-          #AWS_ACCESS_KEY_ID: op://OpenServerless/TESTING/AWS_ACCESS_KEY_ID
-          #AWS_SECRET_ACCESS_KEY: op://OpenServerless/TESTING/AWS_SECRET_ACCESS_KEY
-          #GCLOUD_SERVICE_ACCOUNT_B64: op://OpenServerless/TESTING/GCLOUD_SERVICE_ACCOUNT_B64
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      # Commented out -- GKE plugin not needed without GCP environment:
+      # - name: 'Set up Cloud SDK'
+      #   uses: 'google-github-actions/setup-gcloud@v1'
+      #   if: ${{ startsWith(github.ref_name, 'gke') }}
+      # - name: 'Update plugin'
+      #   if: ${{ startsWith(github.ref_name, 'gke') }}
+      #   run: gcloud components install gke-gcloud-auth-plugin
       - name: Install ops
         shell: powershell
         run: |
@@ -230,12 +213,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-        if: ${{ startsWith(github.ref_name, 'gke') }}
-      - name: 'Update plugin'
-        if: ${{ startsWith(github.ref_name, 'gke') }}
-        run: gcloud components install gke-gcloud-auth-plugin
+      # Commented out -- GKE plugin not needed without GCP environment:
+      # - name: 'Set up Cloud SDK'
+      #   uses: 'google-github-actions/setup-gcloud@v1'
+      #   if: ${{ startsWith(github.ref_name, 'gke') }}
+      # - name: 'Update plugin'
+      #   if: ${{ startsWith(github.ref_name, 'gke') }}
+      #   run: gcloud components install gke-gcloud-auth-plugin
       - name: Install ops
         run: |
           curl -sL bit.ly/get-ops | /bin/bash
@@ -244,29 +228,6 @@ jobs:
           ops -t > /dev/null
           OPS_BIN_PATH=$(ops -i | grep "OPS_HOME" | awk -v FS=: '{print $2}' | tr -d " ")/bin
           echo "PATH=$OPS_BIN_PATH:$PATH" >> $GITHUB_ENV
-      - name: Load secret
-        uses: 1password/load-secrets-action@v2
-        with:
-          # Export loaded secrets as environment variables
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          SSH_KEY: op://OpenServerless/ops_testing_ssh/public key
-          NGROK_PASSWORD: op://OpenServerless/TESTING/NGROK_PASSWORD
-          K3S_IP: op://OpenServerless/TESTING/K3S_IP
-          MK8S_IP: op://OpenServerless/TESTING/MK8S_IP
-          ID_RSA_B64: op://OpenServerless/TESTING/ID_RSA_B64
-          AKS_KUBECONFIG_B64: op://OpenServerless/TESTING/AKS_KUBECONFIG_B64
-          AWS_ACCESS_KEY_ID: op://OpenServerless/TESTING/AWS_ACCESS_KEY_ID
-          AWS_SECRET_ACCESS_KEY: op://OpenServerless/TESTING/AWS_SECRET_ACCESS_KEY
-          AWS_DEFAULT_REGION: op://OpenServerless/TESTING/AWS_DEFAULT_REGION
-          AWS_SSHKEY: op://OpenServerless/TESTING/AWS_SSHKEY
-          EKS_KUBECONFIG_B64: op://OpenServerless/TESTING/EKS_KUBECONFIG_B64
-          #GKE_KUBECONFIG_B64: op://OpenServerless/TESTING/GKE_KUBECONFIG_B64
-          #OPENSHIFT_KUBECONFIG_B64: op://OpenServerless/TESTING/OPENSHIFT_KUBECONFIG_B64
-          #AWS_ACCESS_KEY_ID: op://OpenServerless/TESTING/AWS_ACCESS_KEY_ID
-          #AWS_SECRET_ACCESS_KEY: op://OpenServerless/TESTING/AWS_SECRET_ACCESS_KEY
-          #GCLOUD_SERVICE_ACCOUNT_B64: op://OpenServerless/TESTING/GCLOUD_SERVICE_ACCOUNT_B64
       - name: Debug Action (if requested)
         run: .github/debugAction.sh
       - name: Wait for Debug (if requested)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,7 @@ env:
   K3S_AMD_IP: ${{ secrets.K3S_AMD_IP }}
   K3S_ARM_IP: ${{ secrets.K3S_ARM_IP }}
   ID_RSA_B64: ${{ secrets.ID_RSA_B64 }}
+  SSH_USER: ${{ secrets.SSH_USER || 'root' }}
 
   # --- Generic K8s cluster (kubeconfig-based) ---
   K8S_KUBECONFIG_B64: ${{ secrets.K8S_KUBECONFIG_B64 }}

--- a/tests/1-deploy.sh
+++ b/tests/1-deploy.sh
@@ -16,9 +16,10 @@
 # specific language governing permissions and limitations
 # under the License.
 TYPE="${1:?test type}"
-# Extract platform name: everything before the last '-'
-# e.g. "k3s-amd-test1" -> "k3s-amd", "kind-test1" -> "kind", "k8s-run3" -> "k8s"
-TYPE="$(echo $TYPE | sed 's/-[^-]*$//')"
+# Strip trailing timestamp suffix (digits only) added by tag-based triggers.
+# e.g. "k3s-amd-2603041800" -> "k3s-amd", "kind-2603041800" -> "kind"
+# Clean platform names like "k3s-amd" are left unchanged.
+TYPE="$(echo $TYPE | sed 's/-[0-9]*$//')"
 
 cd "$(dirname $0)"
 

--- a/tests/1-deploy.sh
+++ b/tests/1-deploy.sh
@@ -64,8 +64,8 @@ k3s-amd)
         exit 1
     fi
     # install cluster
-    ops setup server "$(cat _ip)" ubuntu --uninstall
-    ops setup server "$(cat _ip)" ubuntu
+    ops setup server "$(cat _ip)" "${SSH_USER:-root}" --uninstall
+    ops setup server "$(cat _ip)" "${SSH_USER:-root}"
     ;;
 k3s-arm)
     # single ARM VM with k3s installed via ops setup server
@@ -84,8 +84,8 @@ k3s-arm)
         exit 1
     fi
     # install cluster
-    ops setup server "$(cat _ip)" ubuntu --uninstall
-    ops setup server "$(cat _ip)" ubuntu
+    ops setup server "$(cat _ip)" "${SSH_USER:-root}" --uninstall
+    ops setup server "$(cat _ip)" "${SSH_USER:-root}"
     ;;
 
 # ---------------------------------------------------------------

--- a/tests/1-deploy.sh
+++ b/tests/1-deploy.sh
@@ -52,41 +52,30 @@ kind)
 k3s-amd)
     # single AMD VM with k3s installed via ops setup server
     ops config reset
-    if test -n "$K3S_AMD_IP"
+    K3S_AMD_APIHOST="${K3S_AMD_APIHOST:-${APIHOST:-api.k3s-amd.opstest.top}}"
+    if test -z "$K3S_AMD_APIHOST"
     then
-        echo $K3S_AMD_IP>_ip
-        ops config apihost "${K3S_AMD_APIHOST:-${APIHOST:-api.k3s-amd.opstest.top}}"
-    else
-        # Commented out -- Azure provisioning not available:
-        # task azure:vm:config
-        # ops cloud azcloud vm-create k3s-test
-        # ops cloud azcloud zone-update k3s.opstest.top --wildcard --vm=k3s-test
-        echo "ERROR: K3S_AMD_IP is required (Azure provisioning is disabled)"
+        echo "ERROR: K3S_AMD_APIHOST is required"
         exit 1
     fi
-    # install cluster
-    ops setup server "$(cat _ip)" "${SSH_USER:-root}" --uninstall
-    ops setup server "$(cat _ip)" "${SSH_USER:-root}"
+    ops config apihost "$K3S_AMD_APIHOST"
+    # install cluster (SSH via DNS hostname)
+    ops setup server "$K3S_AMD_APIHOST" "${SSH_USER:-root}" --uninstall
+    ops setup server "$K3S_AMD_APIHOST" "${SSH_USER:-root}"
     ;;
 k3s-arm)
     # single ARM VM with k3s installed via ops setup server
     ops config reset
-    if test -n "$K3S_ARM_IP"
+    K3S_ARM_APIHOST="${K3S_ARM_APIHOST:-${APIHOST:-api.k3s-arm.opstest.top}}"
+    if test -z "$K3S_ARM_APIHOST"
     then
-        echo $K3S_ARM_IP>_ip
-        ops config apihost "${K3S_ARM_APIHOST:-${APIHOST:-api.k3s-arm.opstest.top}}"
-    else
-        # Commented out -- Azure provisioning not available:
-        # task azure:vm:config
-        # ops cloud azcloud vm-create k3s-arm-test
-        # ops cloud azcloud zone-update k3s-arm.opstest.top --wildcard --vm=k3s-arm-test
-        # ops cloud aws vm-getip k3s-test >_ip
-        echo "ERROR: K3S_ARM_IP is required (Azure provisioning is disabled)"
+        echo "ERROR: K3S_ARM_APIHOST is required"
         exit 1
     fi
-    # install cluster
-    ops setup server "$(cat _ip)" "${SSH_USER:-root}" --uninstall
-    ops setup server "$(cat _ip)" "${SSH_USER:-root}"
+    ops config apihost "$K3S_ARM_APIHOST"
+    # install cluster (SSH via DNS hostname)
+    ops setup server "$K3S_ARM_APIHOST" "${SSH_USER:-root}" --uninstall
+    ops setup server "$K3S_ARM_APIHOST" "${SSH_USER:-root}"
     ;;
 
 # ---------------------------------------------------------------

--- a/tests/1-deploy.sh
+++ b/tests/1-deploy.sh
@@ -16,7 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 TYPE="${1:?test type}"
-TYPE="$(echo $TYPE | awk -F- '{print $1}')"
+# Extract platform name: everything before the last '-'
+# e.g. "k3s-amd-test1" -> "k3s-amd", "kind-test1" -> "kind", "k8s-run3" -> "k8s"
+TYPE="$(echo $TYPE | sed 's/-[^-]*$//')"
 
 cd "$(dirname $0)"
 
@@ -46,163 +48,193 @@ kind)
     ops setup devcluster --uninstall
     ops setup devcluster
     ;;
-k3s)
-    # create vm and install in the server
+k3s-amd)
+    # single AMD VM with k3s installed via ops setup server
     ops config reset
-    # create vm without k3s
-    if test -n "$K3S_IP"
-    then 
-        echo $K3S_IP>_ip
-        ops config apihost api.k3s.opstest.top
+    if test -n "$K3S_AMD_IP"
+    then
+        echo $K3S_AMD_IP>_ip
+        ops config apihost "${K3S_AMD_APIHOST:-${APIHOST:-api.k3s-amd.opstest.top}}"
     else
-        task azure:vm:config
-        ops cloud azcloud vm-create k3s-test
-        ops cloud azcloud zone-update k3s.opstest.top --wildcard --vm=k3s-test
-        # ops cloud aws vm-getip k3s-test >_ip
+        # Commented out -- Azure provisioning not available:
+        # task azure:vm:config
+        # ops cloud azcloud vm-create k3s-test
+        # ops cloud azcloud zone-update k3s.opstest.top --wildcard --vm=k3s-test
+        echo "ERROR: K3S_AMD_IP is required (Azure provisioning is disabled)"
+        exit 1
     fi
     # install cluster
     ops setup server "$(cat _ip)" ubuntu --uninstall
     ops setup server "$(cat _ip)" ubuntu
     ;;
 k3s-arm)
-    # create vm and install in the server
+    # single ARM VM with k3s installed via ops setup server
     ops config reset
-    # create vm without k3s
     if test -n "$K3S_ARM_IP"
     then
         echo $K3S_ARM_IP>_ip
-        ops config apihost api.k3s-arm.opstest.top
+        ops config apihost "${K3S_ARM_APIHOST:-${APIHOST:-api.k3s-arm.opstest.top}}"
     else
-        task azure:vm:config
-        ops cloud azcloud vm-create k3s-arm-test
-        ops cloud azcloud zone-update k3s-arm.opstest.top --wildcard --vm=k3s-arm-test
-        ops cloud aws vm-getip k3s-test >_ip
+        # Commented out -- Azure provisioning not available:
+        # task azure:vm:config
+        # ops cloud azcloud vm-create k3s-arm-test
+        # ops cloud azcloud zone-update k3s-arm.opstest.top --wildcard --vm=k3s-arm-test
+        # ops cloud aws vm-getip k3s-test >_ip
+        echo "ERROR: K3S_ARM_IP is required (Azure provisioning is disabled)"
+        exit 1
     fi
     # install cluster
     ops setup server "$(cat _ip)" ubuntu --uninstall
     ops setup server "$(cat _ip)" ubuntu
     ;;
-mk8s)
+
+# ---------------------------------------------------------------
+# Commented out -- cloud provider platforms not currently in use.
+# Uncomment and configure the corresponding secrets to re-enable.
+# ---------------------------------------------------------------
+
+# mk8s)
+#     ops config reset
+#     # create vm with mk8s
+#     if test -n "$MK8S_IP"
+#     then
+#           ops config apihost api.mk8s.opstest.top
+#           ops cloud mk8s kubeconfig "$MK8S_IP" ubuntu
+#     else
+#         task azure:vm:config
+#         ops cloud azcloud vm-create mk8s-test
+#         ops cloud azcloud zone-update mk8s.opstest.top --wildcard --vm=mk8s-test
+#         ops cloud azcloud vm-getip mk8s-test >_ip
+#         ops cloud mk8s create "$(cat _ip)" ubuntu
+#         ops cloud mk8s kubeconfig "$(cat _ip)" ubuntu
+#     fi
+#     # install cluster
+#     ops setup cluster --uninstall
+#     ops setup cluster
+#     ;;
+
+# eks)
+#     ops config reset
+#     # create cluster
+#     if test -n "$EKS_KUBECONFIG_B64"
+#     then
+#         mkdir -p ~/.kube
+#         echo $EKS_KUBECONFIG_B64 | base64 -d >~/.kube/config
+#         ops config apihost api.eks.opstest.top
+#         ops config use 0
+#     else
+#         task aws:config
+#         task eks:config
+#         ops cloud eks create
+#         POS=$(ops config use | grep "eks-eks-test" | sed 's/*//' | awk '{print $1}')
+#         if [ "$POS" != "" ]; then
+#           ops config use $POS
+#         else
+#           ops cloud eks kubeconfig
+#         fi
+#         ops cloud eks lb >_cname
+#         ops cloud azcloud zone-update eks.opstest.top --wildcard --cname=$(cat _cname)
+#         # on eks we need to setup an initial apihost resolving the NLB hostname
+#         ops config apihost api.eks.opstest.top
+#     fi
+#     # install cluster
+#     ops debug defin
+#     ops setup cluster --uninstall
+#     ops setup cluster
+#     ;;
+
+# aks)
+#     ops config reset
+#     # create cluster
+#     if test -n "$AKS_KUBECONFIG_B64"
+#     then
+#         mkdir -p ~/.kube
+#         echo $AKS_KUBECONFIG_B64 | base64 -d >~/.kube/config
+#         ops config use 0
+#         ops config apihost api.aks.opstest.top
+#     else
+#         task azure:cluster:config
+#         ops cloud aks create
+#
+#         POS=$(ops config use | grep "aks-aks-test" | sed 's/*//' | awk '{print $1}')
+#         if [ "$POS" != "" ]; then
+#           ops config use $POS
+#         else
+#           ops cloud aks kubeconfig
+#         fi
+#
+#         IP=$(ops cloud aks lb)
+#         ops cloud azcloud zone-update aks.opstest.top --wildcard --ip $IP
+#     fi
+#     # install cluster
+#     ops debug defin
+#     ops setup cluster --uninstall
+#     ops setup cluster
+#     ;;
+
+# gke)
+#     ops config reset
+#     # create cluster
+#     if test -n "$GCLOUD_SERVICE_ACCOUNT_B64"
+#     then
+#         mkdir -p ~/.kube
+#         echo "$GCLOUD_SERVICE_ACCOUNT_B64" | base64 -d  >~/.kube/gcloud.json
+#         gcloud auth activate-service-account --key-file ~/.kube/gcloud.json
+#         gcloud container clusters get-credentials nuvolaris-testing --project nuvolaris-testing --region=us-east1
+#
+#         ops config use 0
+#         ops config apihost api.gke.opstest.top
+#     else
+#         task gcp:vm:config
+#         task aws:vm:config
+#         ops cloud gke create
+#         POS=$(ops config use | grep "gke-gke-test" | sed 's/*//' | awk '{print $1}')
+#         if [ "$POS" != "" ]; then
+#           ops config use $POS
+#         else
+#           ops cloud gke kubeconfig
+#         fi
+#         ops cloud aws zone-update gke.opstest.top --wildcard --ip $(ops cloud gke lb)
+#     fi
+#     # install cluster
+#     ops debug defin
+#     ops setup cluster --uninstall
+#     ops setup cluster
+#     ;;
+
+# osh)
+#     ops config reset
+#     # create cluster
+#     if test -n "$OPENSHIFT_KUBECONFIG_B64"
+#     then
+#         mkdir -p ~/.kube
+#         echo $OPENSHIFT_KUBECONFIG_B64 | base64 -d >~/.kube/config
+#         ops config use 0
+#         ops config apihost api.apps.nuvolaris-testing.oshgcp.opstest.top
+#     else
+#         task osh:create
+#         ops cloud osh import conf/gcp/auth/kubeconfig
+#     fi
+#     # install cluster
+#     ops debug defin
+#     ops setup cluster --uninstall
+#     ops setup cluster
+#     ;;
+
+k8s)
+    # generic Kubernetes cluster accessed via kubeconfig
     ops config reset
-    # create vm with mk8s
-    if test -n "$MK8S_IP"
-    then 
-          ops config apihost api.mk8s.opstest.top
-          ops cloud mk8s kubeconfig "$MK8S_IP" ubuntu
-    else
-        task azure:vm:config
-        ops cloud azcloud vm-create mk8s-test
-        ops cloud azcloud zone-update mk8s.opstest.top --wildcard --vm=mk8s-test
-        ops cloud azcloud vm-getip mk8s-test >_ip
-        ops cloud mk8s create "$(cat _ip)" ubuntu
-        ops cloud mk8s kubeconfig "$(cat _ip)" ubuntu
-    fi
-    # install cluster
-    ops setup cluster --uninstall
-    ops setup cluster
-    ;;
-eks)
-    ops config reset
-    # create cluster
-    if test -n "$EKS_KUBECONFIG_B64"
+    if test -n "$K8S_KUBECONFIG_B64"
     then
         mkdir -p ~/.kube
-        echo $EKS_KUBECONFIG_B64 | base64 -d >~/.kube/config
-        ops config apihost api.eks.opstest.top
+        echo $K8S_KUBECONFIG_B64 | base64 -d > ~/.kube/config
+        ops config apihost "${K8S_APIHOST:-${APIHOST:-api.k8s.opstest.top}}"
         ops config use 0
     else
-        task aws:config
-        task eks:config
-        ops cloud eks create
-        POS=$(ops config use | grep "eks-eks-test" | sed 's/*//' | awk '{print $1}')
-        if [ "$POS" != "" ]; then
-          ops config use $POS
-        else
-          ops cloud eks kubeconfig
-        fi
-        ops cloud eks lb >_cname
-        ops cloud azcloud zone-update eks.opstest.top --wildcard --cname=$(cat _cname)
-        # on eks we need to setup an initial apihost resolving the NLB hostname
-        ops config apihost api.eks.opstest.top
+        echo "ERROR: K8S_KUBECONFIG_B64 is required for k8s platform"
+        exit 1
     fi
     # install cluster
-    ops debug defin
-    ops setup cluster --uninstall
-    ops setup cluster
-    ;;
-aks)
-    ops config reset
-    # create cluster
-    if test -n "$AKS_KUBECONFIG_B64"
-    then
-        mkdir -p ~/.kube
-        echo $AKS_KUBECONFIG_B64 | base64 -d >~/.kube/config
-        ops config use 0
-        ops config apihost api.aks.opstest.top
-    else
-        task azure:cluster:config
-        ops cloud aks create
-
-        POS=$(ops config use | grep "aks-aks-test" | sed 's/*//' | awk '{print $1}')
-        if [ "$POS" != "" ]; then
-          ops config use $POS
-        else
-          ops cloud aks kubeconfig
-        fi
-
-        IP=$(ops cloud aks lb)
-        ops cloud azcloud zone-update aks.opstest.top --wildcard --ip $IP
-    fi
-    # install cluster
-    ops debug defin
-    ops setup cluster --uninstall
-    ops setup cluster
-    ;;
-gke)
-    ops config reset
-    # create cluster
-    if test -n "$GCLOUD_SERVICE_ACCOUNT_B64"
-    then     
-        mkdir -p ~/.kube
-        echo "$GCLOUD_SERVICE_ACCOUNT_B64" | base64 -d  >~/.kube/gcloud.json
-        gcloud auth activate-service-account --key-file ~/.kube/gcloud.json
-        gcloud container clusters get-credentials nuvolaris-testing --project nuvolaris-testing --region=us-east1
-        
-        ops config use 0
-        ops config apihost api.gke.opstest.top
-    else
-        task gcp:vm:config
-        task aws:vm:config
-        ops cloud gke create
-        POS=$(ops config use | grep "gke-gke-test" | sed 's/*//' | awk '{print $1}')
-        if [ "$POS" != "" ]; then
-          ops config use $POS
-        else
-          ops cloud gke kubeconfig
-        fi
-        ops cloud aws zone-update gke.opstest.top --wildcard --ip $(ops cloud gke lb)
-    fi
-    # install cluster
-    ops debug defin
-    ops setup cluster --uninstall
-    ops setup cluster
-    ;;
-
-osh)
-    ops config reset
-    # create cluster
-    if test -n "$OPENSHIFT_KUBECONFIG_B64"
-    then
-        mkdir -p ~/.kube
-        echo $OPENSHIFT_KUBECONFIG_B64 | base64 -d >~/.kube/config
-        ops config use 0
-        ops config apihost api.apps.nuvolaris-testing.oshgcp.opstest.top
-    else
-        task osh:create
-        ops cloud osh import conf/gcp/auth/kubeconfig
-    fi
-    # install cluster
-    ops debug defin
     ops setup cluster --uninstall
     ops setup cluster
     ;;

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -16,21 +16,23 @@
 # specific language governing permissions and limitations
 # under the License.
 TYPE="${1:?test type}"
-TYPE="$(echo $TYPE | awk -F- '{print $1}')"
+# Extract platform name: everything before the last '-'
+# e.g. "k3s-amd-test1" -> "k3s-amd", "kind-test1" -> "kind", "k8s-run3" -> "k8s"
+TYPE="$(echo $TYPE | sed 's/-[^-]*$//')"
 
-# echo
-export OPS_BRANCH=main
+# Use OPS_BRANCH from environment if set, otherwise default to main
+export OPS_BRANCH="${OPS_BRANCH:-main}"
 echo "*** using $OPS_BRANCH ***"
 
 # if type not in (kind, k3s, mk8s, aks, eks, gke) exit
 
 case "$TYPE" in
-"k3s" | "mk8s" | "kind" | "gke" | "aks" | "eks" | "osh")
+"k3s-amd" | "k3s-arm" | "k8s" | "kind" | "mk8s" | "gke" | "aks" | "eks" | "osh")
 	# The TYPE matches one of the allowed values, so continue with the script
 	;;
 *)
 	# TYPE does not match any of the allowed values, so exit with an error message
-	echo "Error: input must be one of 'kind', 'k3s', 'mk8s', 'gke', 'aks', 'eks' or 'osh'."
+	echo "Error: input must be one of 'kind', 'k3s-amd', 'k3s-arm', 'k8s', 'mk8s', 'gke', 'aks', 'eks', or 'osh'."
 	exit 1
 	;;
 esac


### PR DESCRIPTION
## Description

This PR adds a new workflow for testing operator PRs end-to-end.

### Operator PR test workflow (`operator-pr-test.yaml`)

New `repository_dispatch`-driven workflow that receives events from the operator repo when a maintainer comments `/testing <platform>` on a PR. It:

- Clones the operator PR branch with `--recurse-submodules` (picking up the `olaris/` task submodule)
- Builds the operator Docker image from the PR code
- Pushes it to GHCR under the testing repo's namespace (`ghcr.io/<owner>/openserverless-testing:pr-<num>-<sha>`)
- Patches `opsroot.json` to point to the just-built image via `jq`
- Sets `OPS_ROOT` to the submodule path so `ops` uses the PR's task definitions
- Runs the full acceptance test suite against the specified platform

Uses `${{ github.repository_owner }}` throughout, so the same workflow works on forks and upstream without changes.

### Secrets and environment variables
- Secrets are loaded at runtime from 1Password vault `OpenServerless/TESTING` using `1password/load-secrets-action@v2` (Linux/Mac) and `shyim/1password-load-secrets-action@v1` (Windows)
- The only GitHub Secret required is `OP_SERVICE_ACCOUNT_TOKEN` (authenticates the 1Password action)
- `NGROK_TOKEN` remains as a GitHub Secret (not stored in 1Password)
- `OPS_REPO` and `OPS_BRANCH` are configurable via repository variables

### SSH via DNS hostnames

- `1-deploy.sh` uses `K3S_AMD_APIHOST` / `K3S_ARM_APIHOST` as the SSH target

### Bug fix in `tests.yaml`

- Fixed platform name parsing for dispatch-based triggers: the sed pattern was incorrectly stripping platform suffixes (e.g. "amd" from "k3s-amd") when no timestamp was present
- Removed `branches-ignore: '*'` from the `push` trigger (redundant filter that caused the workflow to fire on branch pushes)

### Deploy script updates (`tests/1-deploy.sh`)

- k3s-amd/k3s-arm blocks use `K3S_AMD_APIHOST` / `K3S_ARM_APIHOST` for both `ops config apihost` and `ops setup server` (SSH target)
- SSH connection uses `SSH_USER` variable (defaults to `root`)
- Kubeconfig setup reads from `K8S_KUBECONFIG_B64` for generic K8s platforms

## 1Password vault fields required

```
1Password vault "OpenServerless" / item "TESTING"
  ├── K3S_AMD_APIHOST      DNS FQDN for k3s AMD
  ├── K3S_ARM_APIHOST      DNS FQDN for k3s ARM
  ├── K8S_KUBECONFIG_B64   Base64-encoded kubeconfig for K8s clusters
  ├── K8S_APIHOST          DNS FQDN for generic K8s
  ├── ID_RSA_B64           Base64-encoded SSH key for VM access
  ├── APIHOST              Fallback DNS FQDN
  └── NGROK_PASSWORD       ngrok password (debug)
```

## GitHub Secrets required

| Secret | Purpose |
|---|---|
| `OP_SERVICE_ACCOUNT_TOKEN` | Authenticates 1Password access at runtime |
| `NGROK_TOKEN` | ngrok auth token (debug) |

## Companion PR

This PR works together with a PR on `openserverless-operator` that:
- Adds `openserverless-task` as a git submodule at `olaris/`
- Adds `trigger-testing.yaml` workflow (dispatches `operator-pr-test` events to this repo)
- Requires `OPENSERVERLESS_TESTING_PAT` secret on the operator repo
