### PR TITLE
Add mock OIDC SSO smoke test

### DIFF
--- a/tests/11-sso-mock.sh
+++ b/tests/11-sso-mock.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+set -euo pipefail
+
+TYPE="${1:?test type}"
+TYPE="$(echo "$TYPE" | awk -F- '{print $1}')"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KUBECTL="${KUBECTL:-kubectl}"
+NAMESPACE="${NAMESPACE:-nuvolaris}"
+MOCK_NAME="openserverless-sso-mock"
+MOCK_USER="ssomockuser"
+MOCK_PASSWORD="mock-user-password"
+MOCK_CLIENT_ID="openserverless-sso-mock-client"
+MOCK_CLIENT_SECRET="mock-client-secret"
+MOCK_GROUP="openserverless-users"
+MOCK_ISSUER="http://${MOCK_NAME}.${NAMESPACE}.svc.cluster.local:8080/realms/mock"
+
+if ! ops config sso --help >/dev/null 2>&1; then
+    echo "SSO command is not available in this ops build"
+    exit 1
+fi
+
+if ops config sso show 2>/dev/null | grep -q '^SSO_ENABLED=true$'; then
+    echo "SSO already enabled - skipping mock SSO test to avoid changing an existing setup"
+    exit 0
+fi
+
+cleanup() {
+    set +e
+    ops config sso disable >/dev/null 2>&1
+    "$KUBECTL" -n "$NAMESPACE" delete deployment "$MOCK_NAME" --ignore-not-found >/dev/null 2>&1
+    "$KUBECTL" -n "$NAMESPACE" delete service "$MOCK_NAME" --ignore-not-found >/dev/null 2>&1
+    "$KUBECTL" -n "$NAMESPACE" delete configmap "$MOCK_NAME" --ignore-not-found >/dev/null 2>&1
+    ops admin deleteuser "$MOCK_USER" >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+ops admin deleteuser "$MOCK_USER" >/dev/null 2>&1 || true
+
+ADMIN_API_IMAGE="$("$KUBECTL" -n "$NAMESPACE" get statefulset nuvolaris-system-api -o jsonpath='{.spec.template.spec.containers[0].image}')"
+if [ -z "$ADMIN_API_IMAGE" ]; then
+    echo "FAIL missing admin-api image"
+    exit 1
+fi
+
+"$KUBECTL" -n "$NAMESPACE" create configmap "$MOCK_NAME" \
+    --from-file=mock-oidc-provider.py="$SCRIPT_DIR/mock-oidc-provider.py" \
+    --dry-run=client -o yaml | "$KUBECTL" apply -f -
+
+cat <<EOF | "$KUBECTL" apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${MOCK_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${MOCK_NAME}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${MOCK_NAME}
+  template:
+    metadata:
+      labels:
+        app: ${MOCK_NAME}
+    spec:
+      containers:
+      - name: mock-oidc
+        image: ${ADMIN_API_IMAGE}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /home/openserverless/.venv/bin/python
+        - /mock/mock-oidc-provider.py
+        env:
+        - name: MOCK_OIDC_ISSUER
+          value: "${MOCK_ISSUER}"
+        - name: MOCK_OIDC_CLIENT_ID
+          value: "${MOCK_CLIENT_ID}"
+        - name: MOCK_OIDC_CLIENT_SECRET
+          value: "${MOCK_CLIENT_SECRET}"
+        - name: MOCK_OIDC_USERNAME
+          value: "${MOCK_USER}"
+        - name: MOCK_OIDC_PASSWORD
+          value: "${MOCK_PASSWORD}"
+        - name: MOCK_OIDC_GROUP
+          value: "${MOCK_GROUP}"
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 2
+          periodSeconds: 2
+        volumeMounts:
+        - name: mock-script
+          mountPath: /mock
+      volumes:
+      - name: mock-script
+        configMap:
+          name: ${MOCK_NAME}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${MOCK_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: ${MOCK_NAME}
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+EOF
+
+"$KUBECTL" -n "$NAMESPACE" rollout status "deployment/${MOCK_NAME}" --timeout=120s
+
+ops config sso keycloak --enable \
+    --issuer-url "$MOCK_ISSUER" \
+    --jwks-url "${MOCK_ISSUER}/protocol/openid-connect/certs" \
+    --client-id "$MOCK_CLIENT_ID" \
+    --client-secret "$MOCK_CLIENT_SECRET" \
+    --required-group "$MOCK_GROUP" \
+    --username-claim preferred_username \
+    --groups-claim groups
+
+APIURL="$(ops debug apihost | awk '/whisk API host/{print $4}')"
+if [ -z "$APIURL" ]; then
+    echo "FAIL missing apihost"
+    exit 1
+fi
+
+if OPS_SSO_LOGIN_FLOW=password OPS_PASSWORD="$MOCK_PASSWORD" ops -login "$APIURL" "$MOCK_USER" | grep "Successfully logged in as $MOCK_USER."; then
+    echo SUCCESS SSO PASSWORD LOGIN
+else
+    echo FAIL SSO PASSWORD LOGIN
+    exit 1
+fi
+
+ops util kube waitfor FOR=condition=ready OBJ="wsku/$MOCK_USER" TIMEOUT=120
+
+if ops setup nuvolaris hello | grep hello; then
+    echo SUCCESS SSO HELLO SETUP
+else
+    echo FAIL SSO HELLO SETUP
+    exit 1
+fi
+
+if ops -wsk action list | grep "/$MOCK_USER/hello/hello"; then
+    echo SUCCESS
+    exit 0
+else
+    echo FAIL
+    exit 1
+fi

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -105,6 +105,13 @@ collect ./6-login.sh $TYPE
 
 echo "##############################################"
 echo "#                                            #"
+echo "#          TESTING SSO MOCK $TYPE            #"
+echo "#                                            #"
+echo "##############################################"
+collect ./11-sso-mock.sh $TYPE
+
+echo "##############################################"
+echo "#                                            #"
 echo "#            TESTING STATIC $TYPE            #"
 echo "#                                            #"
 echo "##############################################"

--- a/tests/mock-oidc-provider.py
+++ b/tests/mock-oidc-provider.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import base64
+import json
+import os
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+
+PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+KID = "openserverless-sso-mock"
+
+
+def b64url(value):
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def b64url_int(value):
+    length = (value.bit_length() + 7) // 8
+    return b64url(value.to_bytes(length, byteorder="big"))
+
+
+def write_json(handler, status, payload):
+    body = json.dumps(payload).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def public_jwk():
+    numbers = PRIVATE_KEY.public_key().public_numbers()
+    return {
+        "kty": "RSA",
+        "kid": KID,
+        "use": "sig",
+        "alg": "RS256",
+        "n": b64url_int(numbers.n),
+        "e": b64url_int(numbers.e),
+    }
+
+
+def sign_token():
+    now = int(time.time())
+    issuer = os.environ["MOCK_OIDC_ISSUER"]
+    client_id = os.environ["MOCK_OIDC_CLIENT_ID"]
+    username = os.environ["MOCK_OIDC_USERNAME"]
+    group = os.environ["MOCK_OIDC_GROUP"]
+    payload = {
+        "iss": issuer,
+        "sub": f"mock-sub-{username}",
+        "aud": client_id,
+        "iat": now,
+        "nbf": now - 5,
+        "exp": now + 600,
+        "preferred_username": username,
+        "email": os.environ.get("MOCK_OIDC_EMAIL", f"{username}@example.test"),
+        "groups": [group],
+    }
+    header = {"alg": "RS256", "typ": "JWT", "kid": KID}
+    encoded_header = b64url(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    encoded_payload = b64url(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signing_input = f"{encoded_header}.{encoded_payload}".encode("ascii")
+    signature = PRIVATE_KEY.sign(signing_input, padding.PKCS1v15(), hashes.SHA256())
+    return f"{encoded_header}.{encoded_payload}.{b64url(signature)}"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        print(fmt % args, flush=True)
+
+    def do_GET(self):
+        issuer = os.environ["MOCK_OIDC_ISSUER"]
+        if self.path == "/healthz":
+            write_json(self, 200, {"status": "ok"})
+            return
+        if self.path == "/realms/mock/.well-known/openid-configuration":
+            write_json(
+                self,
+                200,
+                {
+                    "issuer": issuer,
+                    "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+                    "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+                },
+            )
+            return
+        if self.path == "/realms/mock/protocol/openid-connect/certs":
+            write_json(self, 200, {"keys": [public_jwk()]})
+            return
+        write_json(self, 404, {"error": "not_found"})
+
+    def do_POST(self):
+        if self.path != "/realms/mock/protocol/openid-connect/token":
+            write_json(self, 404, {"error": "not_found"})
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        form = parse_qs(self.rfile.read(length).decode("utf-8"))
+        client_id = form.get("client_id", [""])[0]
+        username = form.get("username", [""])[0]
+        password = form.get("password", [""])[0]
+        grant_type = form.get("grant_type", [""])[0]
+
+        if not self._valid_client_auth(client_id):
+            write_json(self, 401, {"error": "invalid_client"})
+            return
+        if grant_type != "password":
+            write_json(self, 400, {"error": "unsupported_grant_type"})
+            return
+        if username != os.environ["MOCK_OIDC_USERNAME"] or password != os.environ["MOCK_OIDC_PASSWORD"]:
+            write_json(self, 400, {"error": "invalid_grant"})
+            return
+
+        write_json(
+            self,
+            200,
+            {
+                "access_token": sign_token(),
+                "token_type": "Bearer",
+                "expires_in": 600,
+            },
+        )
+
+    def _valid_client_auth(self, form_client_id):
+        expected_id = os.environ["MOCK_OIDC_CLIENT_ID"]
+        expected_secret = os.environ["MOCK_OIDC_CLIENT_SECRET"]
+        authorization = self.headers.get("Authorization", "")
+        if authorization.startswith("Basic "):
+            raw = base64.b64decode(authorization.split(" ", 1)[1]).decode("utf-8")
+            client_id, client_secret = raw.split(":", 1)
+            return client_id == expected_id and client_secret == expected_secret
+        return form_client_id == expected_id and not expected_secret
+
+
+if __name__ == "__main__":
+    HTTPServer(("0.0.0.0", 8080), Handler).serve_forever()


### PR DESCRIPTION
## Summary
- add Kubernetes-internal mock OIDC provider for SSO smoke tests
- issue RS256/JWKS tokens from a mock password grant endpoint
- add SSO test script that configures ops SSO, verifies password-grant login, deploys hello, and cleans up
- skip safely when SSO is already enabled to avoid overwriting existing clusters

## Tests
- bash -n tests/11-sso-mock.sh
- bash -n tests/all.sh
- python3 -m py_compile tests/mock-oidc-provider.py
- ./tests/11-sso-mock.sh kind (skipped because current cluster already has SSO enabled)