### PR TITLE
fix: propagate and retry SSO test failures

### DIFF
--- a/tests/1-deploy.sh
+++ b/tests/1-deploy.sh
@@ -47,6 +47,7 @@ kind)
         ops config reset
         ops config slim
         ops setup devcluster
+        ops setup nuvolaris system-api deploy
     fi
     ;;
 k3s)

--- a/tests/11-sso-mock.sh
+++ b/tests/11-sso-mock.sh
@@ -29,6 +29,8 @@ MOCK_CLIENT_ID="openserverless-sso-mock-client"
 MOCK_CLIENT_SECRET="mock-client-secret"
 MOCK_GROUP="openserverless-users"
 MOCK_ISSUER="http://${MOCK_NAME}.${NAMESPACE}.svc.cluster.local:8080/realms/mock"
+SSO_LOGIN_TIMEOUT_SECONDS="${SSO_LOGIN_TIMEOUT_SECONDS:-120}"
+SSO_LOGIN_RETRY_SECONDS="${SSO_LOGIN_RETRY_SECONDS:-2}"
 
 if ! ops config sso --help >/dev/null 2>&1; then
     echo "SSO command is not available in this ops build"
@@ -147,12 +149,28 @@ if [ -z "$APIURL" ]; then
     exit 1
 fi
 
-if OPS_SSO_LOGIN_FLOW=password OPS_PASSWORD="$MOCK_PASSWORD" ops -login "$APIURL" "$MOCK_USER" | grep "Successfully logged in as $MOCK_USER."; then
-    echo SUCCESS SSO PASSWORD LOGIN
-else
-    echo FAIL SSO PASSWORD LOGIN
-    exit 1
-fi
+LOGIN_DEADLINE=$((SECONDS + SSO_LOGIN_TIMEOUT_SECONDS))
+while true; do
+    if LOGIN_OUTPUT="$(OPS_SSO_LOGIN_FLOW=password OPS_PASSWORD="$MOCK_PASSWORD" ops -login "$APIURL" "$MOCK_USER" 2>&1)" && \
+        grep -Fq "Successfully logged in as $MOCK_USER." <<<"$LOGIN_OUTPUT"; then
+        printf '%s\n' "$LOGIN_OUTPUT"
+        echo SUCCESS SSO PASSWORD LOGIN
+        break
+    fi
+
+    printf '%s\n' "$LOGIN_OUTPUT"
+    if ! grep -Eq 'OIDC password login failed \((502|503)\)' <<<"$LOGIN_OUTPUT"; then
+        echo FAIL SSO PASSWORD LOGIN
+        exit 1
+    fi
+    if (( SECONDS >= LOGIN_DEADLINE )); then
+        echo "FAIL SSO PASSWORD LOGIN timed out after ${SSO_LOGIN_TIMEOUT_SECONDS}s"
+        exit 1
+    fi
+
+    echo "admin-api ingress not ready; retrying SSO password login in ${SSO_LOGIN_RETRY_SECONDS}s"
+    sleep "$SSO_LOGIN_RETRY_SECONDS"
+done
 
 ops util kube waitfor FOR=condition=ready OBJ="wsku/$MOCK_USER" TIMEOUT=120
 

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -15,6 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+set -o pipefail
+
 TYPE="${1:?test type}"
 TYPE="$(echo $TYPE | awk -F- '{print $1}')"
 
@@ -45,12 +47,14 @@ esac
 
 cd "$SCRIPT_DIR"
 rm  -f _results _log
+FAILED=0
 collect() {
 	if "$@" 2>&1 | tee _log
 	then
 		echo SUCCESS "$1" >> _results
 	else
 		echo FAIL "$1" >> _results
+		FAILED=1
 	fi
 }
 
@@ -154,3 +158,4 @@ collect ./14-runtime-testing.sh $TYPE
 
 echo "============================================"
 cat _results
+exit "$FAILED"


### PR DESCRIPTION
## Summary
- deploy system-api when creating the Kind test cluster
- preserve per-test failures through the `tee` pipeline and return a non-zero suite exit status
- retry only transient 502/503 responses while ingress catches up after the admin-api rollout

## Validation
- `bash -n tests/all.sh tests/11-sso-mock.sh`
- `./tests/11-sso-mock.sh kind` in the Lima Kind VM: first request 503, retry 200, final exit code 0
- full runner verified to report failed test scripts and exit non-zero