### PR TITLE
fix: use PIPESTATUS to capture correct exit code in collect()

### DIFF
--- a/tests/all.sh
+++ b/tests/all.sh
@@ -49,7 +49,8 @@ cd "$SCRIPT_DIR"
 rm  -f _results _log
 FAILED=0
 collect() {
-	if "$@" 2>&1 | tee _log
+	"$@" 2>&1 | tee _log
+	if [ ${PIPESTATUS[0]} -eq 0 ]
 	then
 		echo SUCCESS "$1" >> _results
 	else


### PR DESCRIPTION
The `collect()` function in `tests/all.sh` used:

```bash
if "$@" 2>&1 | tee _log
```

This captures the exit status of `tee` (always 0) instead of the tested script's own exit code, because bash pipelines report `$?` from the last command in the pipe.

As a result, every test script that fails with a non-zero exit code was still recorded as SUCCESS in `_results` and in the final summary.

Confirmed on a kind cluster: after this fix, `5-sys-seaweedfs.sh` and `11-sso-mock.sh`, which fail with a real error, are now correctly reported as FAIL instead of SUCCESS. The overall `task test` run now also exits non-zero when a test genuinely fails, instead of always reporting success.

Fix: check `${PIPESTATUS[0]}` (the exit code of the first command in the pipeline) instead of the pipeline's own exit status.